### PR TITLE
Fix memory leak in is_it_prime_eratosthenes()

### DIFF
--- a/algorithms/math/prime_numbers.c
+++ b/algorithms/math/prime_numbers.c
@@ -48,9 +48,10 @@ bool is_it_prime_eratosthenes (int n)
 
   for (c = 2; c <= sqr; c++) { // run through primes and multiples of them.
     if (primes[c]) {           // mark the multiples as not primes.
-      if (n % c == 0)
+      if (n % c == 0) {
+        free (primes);
         return FALSE;
-      else {
+      } else {
         for (d = 2; (d * c) < sqr; d++) {
           primes[d*c] = FALSE;
         }


### PR DESCRIPTION
Hey Luis! 😄 

I just found a link to `algorithms/math/prime_numbers.c` in Reddit. There is a memory leak in an early return in `is_it_prime_eratosthenes`.